### PR TITLE
Add support for ramsey/uuid v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-json": "*",
         "eventsauce/eventsauce": "^0.7.0|^0.8.0",
         "doctrine/dbal": "^2.5",
-        "ramsey/uuid": "^3.6"
+        "ramsey/uuid": "^3 || ^4"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|9.5"


### PR DESCRIPTION
## Summary
This pull request updates the `ramsey/uuid` dependency to allow installing version 4 in addition to the current 3.x constraint.

## Changes
- Relaxed the `ramsey/uuid` version constraint in `composer.json` from:
`^3.6` to `^3 || ^4.0`
No behaviour changes are intended; this is a dependency-constraint update only.

## Rationale
- `ramsey/uuid` 3.x is quite old and many modern libraries and applications already depend on `ramsey/uuid` 4.x.
- Allowing `^4.0` reduces version conflicts in consuming projects and makes it easier to integrate this package into newer codebases.
- The public API used by this package remains compatible between 3.x and 4.x, so broadening the constraint is safe.

## Backwards Compatibility
- Existing users pinned to `ramsey/uuid` 3.x remain supported via `^3`.
- Projects that already use `ramsey/uuid` 4.x can now install `eventsauce/doctrine-outbox-message-dispatcher` without forcing a downgrade.
